### PR TITLE
Add optional zeros to G0[123] and M02 commands

### DIFF
--- a/language/syntaxes/gerber.tmLanguage.json
+++ b/language/syntaxes/gerber.tmLanguage.json
@@ -27,11 +27,11 @@
     ],
     "repository": {
         "g_code": {
-            "match": "(G0?1|G0?2|G0?3|G36|G37|G54|G55|G70|G71|G74|G75|G90|G91)",
+            "match": "(G0*1|G0*2|G0*3|G36|G37|G54|G55|G70|G71|G74|G75|G90|G91)",
             "name": "keyword.g_code"
         },
         "draw_operations": {
-            "match": "(D0?1|D0?2|D0?3)",
+            "match": "(D0*1|D0*2|D0*3)",
             "name": "keyword.draw_operation"
         },
         "aperture_specification": {
@@ -99,7 +99,7 @@
             }
         },
         "comment": {
-            "begin": "G0?4",
+            "begin": "G0*4",
             "end": "(?=(\\*))",
             "beginCaptures": {
                 "0": { "name": "keyword" }
@@ -116,7 +116,7 @@
             "name": "comment"
         },
         "attribute_comment": {
-            "begin": "(G0?4)\\s*(#@!)",
+            "begin": "(G0*4)\\s*(#@!)",
             "end": "(?=(\\*))",
             "beginCaptures": {
                 "1": { "name": "keyword" },
@@ -376,7 +376,7 @@
         },
         "end-of-file": {
             "name": "keyword",
-            "match": "(M0?2|M0?1|M0?0)"
+            "match": "(M0*2|M0*1|M0*0)"
         }
     }
 }

--- a/language/syntaxes/gerber.tmLanguage.json
+++ b/language/syntaxes/gerber.tmLanguage.json
@@ -27,11 +27,11 @@
     ],
     "repository": {
         "g_code": {
-            "match": "(G01|G02|G03|G36|G37|G54|G55|G70|G71|G74|G75|G90|G91)",
+            "match": "(G0?1|G0?2|G0?3|G36|G37|G54|G55|G70|G71|G74|G75|G90|G91)",
             "name": "keyword.g_code"
         },
         "draw_operations": {
-            "match": "(D01|D02|D03)",
+            "match": "(D0?1|D0?2|D0?3)",
             "name": "keyword.draw_operation"
         },
         "aperture_specification": {
@@ -99,7 +99,7 @@
             }
         },
         "comment": {
-            "begin": "G04",
+            "begin": "G0?4",
             "end": "(?=(\\*))",
             "beginCaptures": {
                 "0": { "name": "keyword" }
@@ -116,7 +116,7 @@
             "name": "comment"
         },
         "attribute_comment": {
-            "begin": "(G04)\\s*(#@!)",
+            "begin": "(G0?4)\\s*(#@!)",
             "end": "(?=(\\*))",
             "beginCaptures": {
                 "1": { "name": "keyword" },
@@ -376,7 +376,7 @@
         },
         "end-of-file": {
             "name": "keyword",
-            "match": "(M02|M01|M00)"
+            "match": "(M0?2|M0?1|M0?0)"
         }
     }
 }


### PR DESCRIPTION
Add optional zeros in the syntax package for G and M commands. 

It is a common output method for Laser cut stencil systems. 